### PR TITLE
Fix an issue in an edge case where sinks are disposed while broadcasting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "rollup -c && cpy src/*.js.flow dist/",
     "typecheck": "tsc --noEmit && flow check",
     "prepare": "yarn build",
-    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha"
+    "test:unit": "TS_NODE_PROJECT=test/tsconfig.json mocha"
   },
   "devDependencies": {
     "@briancavalier/assert": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "rollup -c && cpy src/*.js.flow dist/",
     "typecheck": "tsc --noEmit && flow check",
     "prepare": "yarn build",
-    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ./node_modules/.bin/mocha -r ts-node/register src/*.test.ts"
+    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha"
   },
   "devDependencies": {
     "@briancavalier/assert": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -15,15 +15,14 @@
     "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ./node_modules/.bin/mocha -r ts-node/register src/*.test.ts"
   },
   "devDependencies": {
+    "@briancavalier/assert": "^3.4.0",
     "@most/core": "^1.5.0",
     "@most/scheduler": "^1.2.3",
     "@types/mocha": "^5.2.7",
-    "@types/power-assert": "^1.5.0",
     "@types/sinon": "^7.0.13",
     "cpy-cli": "^2.0.0",
     "flow-bin": "^0.89.0",
     "mocha": "^6.1.4",
-    "power-assert": "^1.6.1",
     "rollup": "^1.0.1",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-typescript2": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,24 @@
   "scripts": {
     "build": "rollup -c && cpy src/*.js.flow dist/",
     "typecheck": "tsc --noEmit && flow check",
-    "prepare": "yarn build"
+    "prepare": "yarn build",
+    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ./node_modules/.bin/mocha -r ts-node/register src/*.test.ts"
   },
   "devDependencies": {
+    "@most/core": "^1.5.0",
+    "@most/scheduler": "^1.2.3",
+    "@types/mocha": "^5.2.7",
+    "@types/power-assert": "^1.5.0",
+    "@types/sinon": "^7.0.13",
     "cpy-cli": "^2.0.0",
     "flow-bin": "^0.89.0",
+    "mocha": "^6.1.4",
+    "power-assert": "^1.6.1",
     "rollup": "^1.0.1",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-typescript2": "^0.18.1",
+    "sinon": "^7.3.2",
+    "ts-node": "^8.3.0",
     "typescript": "^3.2.2"
   },
   "dependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { tap, take, runEffects } from "@most/core";
 import { newDefaultScheduler } from "@most/scheduler";
 import { describe, it } from "mocha";
-import assert from "power-assert";
+import { assert } from "@briancavalier/assert";
 import { createAdapter } from "./index";
 import { fake } from "sinon";
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,22 @@
+import { tap, take, runEffects } from "@most/core";
+import { newDefaultScheduler } from "@most/scheduler";
+import { describe, it } from "mocha";
+import assert from "power-assert";
+import { createAdapter } from "./index";
+import { fake } from "sinon";
+
+describe("createAdapter", () => {
+  it("broadcasts to all sinks even when the sinks are removed while broadcasting", () => {
+    const [induce, events] = createAdapter();
+    const f1 = fake();
+    const f2 = fake();
+    const s1 = take(1, tap(f1, events));
+    const s2 = take(1, tap(f2, events));
+    const scheduler = newDefaultScheduler();
+    runEffects(s1, scheduler);
+    runEffects(s2, scheduler);
+    induce(undefined);
+    assert(f1.called);
+    assert(f2.called);
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,22 +1,22 @@
-import { tap, take, runEffects } from "@most/core";
-import { newDefaultScheduler } from "@most/scheduler";
-import { describe, it } from "mocha";
-import { assert } from "@briancavalier/assert";
-import { createAdapter } from "./index";
-import { fake } from "sinon";
+import { tap, take, runEffects } from '@most/core'
+import { newDefaultScheduler } from '@most/scheduler'
+import { describe, it } from 'mocha'
+import { assert } from '@briancavalier/assert'
+import { createAdapter } from './index'
+import { fake } from 'sinon'
 
-describe("createAdapter", () => {
-  it("broadcasts to all sinks even when the sinks are removed while broadcasting", () => {
-    const [induce, events] = createAdapter();
-    const f1 = fake();
-    const f2 = fake();
-    const s1 = take(1, tap(f1, events));
-    const s2 = take(1, tap(f2, events));
-    const scheduler = newDefaultScheduler();
-    runEffects(s1, scheduler);
-    runEffects(s2, scheduler);
-    induce(undefined);
-    assert(f1.called);
-    assert(f2.called);
-  });
-});
+describe('createAdapter', () => {
+  it('broadcasts to all sinks even when the sinks are removed while broadcasting', () => {
+    const [induce, events] = createAdapter()
+    const f1 = fake()
+    const f2 = fake()
+    const s1 = take(1, tap(f1, events))
+    const s2 = take(1, tap(f2, events))
+    const scheduler = newDefaultScheduler()
+    runEffects(s1, scheduler)
+    runEffects(s2, scheduler)
+    induce(undefined)
+    assert(f1.called)
+    assert(f2.called)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,50 +4,30 @@ export type Adapter<A, B> = [(event: A) => void, Stream<B>]
 
 export const createAdapter = <A> (): Adapter<A, A> => {
   const sinks: { sink: Sink<A>, scheduler: Scheduler }[] = []
-  let locked: boolean = false
-  const queue: { sink: Sink<A>, scheduler: Scheduler }[] = []
-  const removeSink = (sink: { sink: Sink<A>, scheduler: Scheduler }) => {
-    if (locked) {
-      queue.push(sink)
-    } else {
-      remove(sinks, sink)
-    }
-  }
-  return [a => {
-    locked = true
-    broadcast(sinks, a)
-    locked = false
-    if (queue.length > 0) {
-      queue.forEach(sink => remove(sinks, sink))
-      queue.length = 0
-    }
-  }, new FanoutPortStream(sinks, removeSink)]
+  return [a => broadcast(sinks, a), new FanoutPortStream(sinks)]
 }
 
 const broadcast = <A> (sinks: { sink: Sink<A>, scheduler: Scheduler }[], a: A): void =>
-  sinks.forEach(({ sink, scheduler }) => tryEvent(scheduler.currentTime(), a, sink))
+  sinks.slice().forEach(({ sink, scheduler }) => tryEvent(scheduler.currentTime(), a, sink))
 
 export class FanoutPortStream<A> {
-  constructor (
-    private readonly sinks: { sink: Sink<A>, scheduler: Scheduler }[],
-    private readonly removeSink: (sink: { sink: Sink<A>, scheduler: Scheduler }) => void
-  ) {}
+  constructor (private readonly sinks: { sink: Sink<A>, scheduler: Scheduler }[]) {}
 
   run (sink: Sink<A>, scheduler: Scheduler): Disposable {
     const s = { sink, scheduler }
     this.sinks.push(s)
-    return new RemovePortDisposable(s, this.removeSink)
+    return new RemovePortDisposable(s, this.sinks)
   }
 }
 
 export class RemovePortDisposable<A> implements Disposable {
-  constructor (
-    private readonly sink: { sink: Sink<A>, scheduler: Scheduler },
-    private readonly removeSink: (sink: { sink: Sink<A>, scheduler: Scheduler }) => void
-  ) {}
+  constructor (private readonly sink: { sink: Sink<A>, scheduler: Scheduler }, private readonly sinks: { sink: Sink<A>, scheduler: Scheduler }[]) {}
 
   dispose () {
-    this.removeSink(this.sink)
+    const i = this.sinks.indexOf(this.sink)
+    if(i >= 0) {
+      this.sinks.splice(i, 1)
+    }
   }
 }
 
@@ -56,12 +36,5 @@ function tryEvent <A> (t: Time, a: A, sink: Sink<A>) {
     sink.event(t, a)
   } catch(e) {
     sink.error(t, e)
-  }
-}
-
-function remove <A> (arr: A[], elm: A) {
-  const i = arr.indexOf(elm)
-  if (i >= 0) {
-    arr.splice(i, 1)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,30 +4,50 @@ export type Adapter<A, B> = [(event: A) => void, Stream<B>]
 
 export const createAdapter = <A> (): Adapter<A, A> => {
   const sinks: { sink: Sink<A>, scheduler: Scheduler }[] = []
-  return [a => broadcast(sinks, a), new FanoutPortStream(sinks)]
+  let locked: boolean = false
+  const queue: { sink: Sink<A>, scheduler: Scheduler }[] = []
+  const removeSink = (sink: { sink: Sink<A>, scheduler: Scheduler }) => {
+    if (locked) {
+      queue.push(sink)
+    } else {
+      remove(sinks, sink)
+    }
+  }
+  return [a => {
+    locked = true
+    broadcast(sinks, a)
+    locked = false
+    if (queue.length > 0) {
+      queue.forEach(sink => remove(sinks, sink))
+      queue.length = 0
+    }
+  }, new FanoutPortStream(sinks, removeSink)]
 }
 
 const broadcast = <A> (sinks: { sink: Sink<A>, scheduler: Scheduler }[], a: A): void =>
   sinks.forEach(({ sink, scheduler }) => tryEvent(scheduler.currentTime(), a, sink))
 
 export class FanoutPortStream<A> {
-  constructor (private readonly sinks: { sink: Sink<A>, scheduler: Scheduler }[]) {}
+  constructor (
+    private readonly sinks: { sink: Sink<A>, scheduler: Scheduler }[],
+    private readonly removeSink: (sink: { sink: Sink<A>, scheduler: Scheduler }) => void
+  ) {}
 
   run (sink: Sink<A>, scheduler: Scheduler): Disposable {
     const s = { sink, scheduler }
     this.sinks.push(s)
-    return new RemovePortDisposable(s, this.sinks)
+    return new RemovePortDisposable(s, this.removeSink)
   }
 }
 
 export class RemovePortDisposable<A> implements Disposable {
-  constructor (private readonly sink: { sink: Sink<A>, scheduler: Scheduler }, private readonly sinks: { sink: Sink<A>, scheduler: Scheduler }[]) {}
+  constructor (
+    private readonly sink: { sink: Sink<A>, scheduler: Scheduler },
+    private readonly removeSink: (sink: { sink: Sink<A>, scheduler: Scheduler }) => void
+  ) {}
 
   dispose () {
-    const i = this.sinks.indexOf(this.sink)
-    if(i >= 0) {
-      this.sinks.splice(i, 1)
-    }
+    this.removeSink(this.sink)
   }
 }
 
@@ -36,5 +56,12 @@ function tryEvent <A> (t: Time, a: A, sink: Sink<A>) {
     sink.event(t, a)
   } catch(e) {
     sink.error(t, e)
+  }
+}
+
+function remove <A> (arr: A[], elm: A) {
+  const i = arr.indexOf(elm)
+  if (i >= 0) {
+    arr.splice(i, 1)
   }
 }

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -2,7 +2,7 @@ import { tap, take, runEffects } from '@most/core'
 import { newDefaultScheduler } from '@most/scheduler'
 import { describe, it } from 'mocha'
 import { assert } from '@briancavalier/assert'
-import { createAdapter } from './index'
+import { createAdapter } from '../src/index'
 import { fake } from 'sinon'
 
 describe('createAdapter', () => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--require ts-node/register
+test/**/*-test.ts

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
Hello,

I found that disposing a sink, which is registered as a target of broadcasting, while broadcasting breaks succeeding broadcasting. This test proves the case.
The reason why it happens is that `broadcast` relies on `forEach`, but `forEach` does not care if the length of the array is changed while iterating. So it skips following sinks when `sinks` is shortened with `splice` while broadcasting.

Making a lock for broadcasting and deferring removing sinks after broadcasting solves the problem. But there might be better solution for the problem. Feel free to request changes.

I also installed testing environment to write the case. But I think it should fit main maintainer's preference. So please request changes if needed, too.

Thank you.