### PR TITLE
add induceError and induceEnd

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = LF

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .rpt2_cache/
 dist/
+.idea

--- a/README.md
+++ b/README.md
@@ -21,20 +21,27 @@ yarn add @most/adapter
 ### Adapter<A, B>
 
 ```typescript
-type Adapter<A, B> = [(event: A) => void, Stream<B>]
+type Adapter<A, B> = [(event: A) => void, Stream<B>, (e: Error) => void, () => void]
 ```
 
-An adapter is an entangled pair of an event stream, and a function to induce (cause) events in that stream.
+An adapter is an entangled tuple of an event stream, and a functions to induce (cause) events or an error in that stream, or to end it.
 
-### createAdapter :: () → Adapter<A, A>
+### createAdapter :: () → Adapter A, A
 
 Create an Adapter.
 
 ```typescript
-const [induce, events] = createAdapter<string>()
+const [induce, events, induceError] = createAdapter<string>()
 
 // Cause an event with value "hello" to occur in events.
 induce('hello')
 // Cause an event with value "world" to occur in events.
 induce('world')
+// Cause events to fail with the error
+induceError(new Error("oops!"))
+
+const [, eventsToo, , endStream] = createAdapter<any>()
+
+// Cause eventsToo to end w/o a value
+endStream()
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@most/adapter",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "author": "Brian Cavalier <brian@briancavalier.com>",

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -19,4 +19,59 @@ describe('createAdapter', () => {
     assert(f1.called)
     assert(f2.called)
   })
+
+  it ('broadcasts an error event', () :Promise<any> => {
+    const [induce, s, induceError] = createAdapter()
+    const sampleError = new Error("sample error")
+    const f1 = fake()
+    const f2 = fake()
+    const s1 = tap(f1, s)
+    const s2 = tap(f2, s)
+    const scheduler = newDefaultScheduler()
+    const retVal = Promise.all([
+      runEffects(s1, scheduler)
+      .then(
+        () => { assert(false); },
+        (e: Error) => {
+          assert(e === sampleError);
+          assert(f1.notCalled);
+        }
+      ),
+      runEffects(s2, scheduler)
+      .then(
+        () => { assert(false); },
+        (e: Error) => {
+          assert(e === sampleError);
+          assert(f2.notCalled);
+        }
+      )
+    ])
+
+    induceError(sampleError);
+    induce(undefined);
+
+    return retVal
+  })
+
+  it ('ends all observers after emitting an event', () => {
+    const [induce, s, , induceEnd] = createAdapter()
+    const sampleEvent = { foo: 'bar' }
+    const f1 = fake()
+    const f2 = fake()
+    const s1 = tap(f1, s)
+    const s2 = tap(f2, s)
+    const scheduler = newDefaultScheduler()
+    const retVal = Promise.all([
+      runEffects(s1, scheduler)
+      .then(() => { assert(f1.calledOnceWith(sampleEvent)) }),
+      runEffects(s2, scheduler)
+      .then(() => { assert(f2.calledOnceWith(sampleEvent)) })
+    ])
+
+    induce(sampleEvent);
+    induceEnd();
+
+    return retVal
+  })
+
 })

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "lib": ["es2015"]
   }
 }


### PR DESCRIPTION
I needed that in one place, and I guess, this completes the API.

Should be backwards compatible.

What do you think?
Edit:
I saw that #1 already discusses `induceEnd` and `induceError` and warns about race conditions, only after writing my own implementation in JS and also completing this PR. 

To illustrate my use case: 
I have a loop which
- polls data via `fetch`, 
- on success or tolerable error (e.g. timeout) the loop waits a certain amount of time
-  before it continues to the next iteration.
 
The results a processed by a consumer `Stream` into which I `induceValue` inside the loop. However, if `fetch` fails severely (e.g. with HTTP error code 400-499) I'd like to process that using the same consumer `Stream`. Thus, inside the loop I need to `induceError`.

